### PR TITLE
Fix up android jni makefiles

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,5 +1,10 @@
 LOCAL_PATH := $(call my-dir)
 
+ARM_ASM  = 0
+SOURCES :=
+DEFINES :=
+COMMON_DEFINES :=
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := retro
@@ -8,16 +13,7 @@ ifeq ($(TARGET_ARCH),arm)
 ARM_ASM         = 1
 ASM_CPU         = 0
 ASM_SPC700      = 0
-LOCAL_CFLAGS   += -DANDROID_ARM
 LOCAL_ARM_MODE := arm
-endif
-
-ifeq ($(TARGET_ARCH),x86)
-LOCAL_CFLAGS   +=  -DANDROID_X86
-endif
-
-ifeq ($(TARGET_ARCH),mips)
-LOCAL_CFLAGS   += -DANDROID_MIPS -D__mips__ -D__MIPSEL__
 endif
 
 ifeq ($(NDK_DEBUG),1)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,1 +1,2 @@
-APP_ABI := armeabi armeabi-v7a
+APP_ABI := all
+NDK_TOOLCHAIN_VERSION := 4.9


### PR DESCRIPTION
Arm asm fails to compile with clang, so force gcc for jni