### PR TITLE
Fix controller input for Super Mario All-Stars

### DIFF
--- a/src/snes9x.h
+++ b/src/snes9x.h
@@ -125,7 +125,6 @@ enum
 {
    SNES_MULTIPLAYER5,
    SNES_JOYPAD,
-   SNES_MOUSE_SWAPPED,
    SNES_MOUSE,
    SNES_SUPERSCOPE,
    SNES_JUSTIFIER,
@@ -253,7 +252,6 @@ typedef struct
    bool8  TraceDSP;
 
    // Joystick options
-   bool8  SwapJoypads;
    bool8  JoystickEnabled;
 
    // ROM timing options (see also H_Max above)


### PR DESCRIPTION
This PR just backports the input fix added in [snes9x2005 commit bc74743](https://github.com/libretro/snes9x2005/commit/bc7474392a91fa9838e6ecb5b16ccebdd97ab9ec).

This allows for proper control of Super Mario All-Stars.

