### PR TITLE
recover 1 frame of input lag

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -469,6 +469,9 @@ void retro_run (void)
    IPPU.RenderThisFrame = TRUE;
 #endif
 
+   poll_cb();
+   report_buttons();
+
    S9xMainLoop();
 //   asm_S9xMainLoop();
    S9xMixSamples(audio_buf, avail);
@@ -478,10 +481,6 @@ void retro_run (void)
    if(!IPPU.RenderThisFrame)
       video_cb(NULL, IPPU.RenderedScreenWidth, IPPU.RenderedScreenHeight, GFX_PITCH);
 #endif
-
-   poll_cb();
-
-   report_buttons();
 }
 
 size_t retro_serialize_size (void)


### PR DESCRIPTION
Still 1 to go by adapting Brunnis fix [(from the 2005 core here)](https://github.com/libretro/snes9x2005/commit/b3711dfa5041d08490a8603fe221f267c0da290a#diff-c8ca0e6ae501850e59bc299c66807f37).