### PR TITLE
Fix save state size

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -100,7 +100,13 @@ memstream_t *s_stream;
 
 int s_open(const char *fname, const char *mode)
 {
-   s_stream = memstream_open(0);
+   unsigned writing = 0;
+
+   if (mode)
+      if (strcmp(mode, "wb") == 0)
+         writing = 1;
+
+   s_stream = memstream_open(writing);
    return TRUE;
 }
 


### PR DESCRIPTION
The core currently suffers from a (trivial) bug that means save states have a size of ~5MB (!). This is far too large. As a result, save states have significant performance overheads on devices with slow storage (e.g. 3DS).

This PR fixes the bug. Save state now have a size of ~420kb.