### PR TITLE
gfx: Remove unused settings and code

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -763,7 +763,7 @@ unsigned retro_get_region (void)
    return Settings.PAL ? RETRO_REGION_PAL : RETRO_REGION_NTSC; 
 }
 
-bool8 S9xDeinitUpdate(int width, int height, bool8 sixteen_bit)
+bool8 S9xDeinitUpdate(int width, int height)
 {
 	int y;
 
@@ -803,7 +803,6 @@ bool8 S9xDeinitUpdate(int width, int height, bool8 sixteen_bit)
 
 
 /* Dummy functions that should probably be implemented correctly later. */
-bool8 S9xInitUpdate(void) { return TRUE; }
 bool8 S9xContinueUpdate(int width, int height) { return TRUE; }
 void S9xSetPalette(void) {}
 void S9xLoadSDD1Data(void) {}

--- a/src/gfx.c
+++ b/src/gfx.c
@@ -561,11 +561,6 @@ void S9xStartScreenRefresh()
 {
    if (IPPU.RenderThisFrame)
    {
-      if (!S9xInitUpdate())
-      {
-         IPPU.RenderThisFrame = FALSE;
-         return;
-      }
       IPPU.RenderedFramesCount++;
       IPPU.PreviousLine = IPPU.CurrentLine = 0;
       IPPU.MaxBrightness = PPU.Brightness;
@@ -641,8 +636,7 @@ void S9xEndScreenRefresh()
          IPPU.ColorsChanged = FALSE;
 
 
-      S9xDeinitUpdate(IPPU.RenderedScreenWidth, IPPU.RenderedScreenHeight,
-                      1);
+      S9xDeinitUpdate(IPPU.RenderedScreenWidth, IPPU.RenderedScreenHeight);
    }
 
 #ifdef LAGFIX

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -313,8 +313,7 @@ extern SGFX GFX;
 
 bool8_32 S9xGraphicsInit();
 void S9xGraphicsDeinit();
-bool8_32 S9xInitUpdate(void);
-bool8_32 S9xDeinitUpdate(int Width, int Height, bool8_32 sixteen_bit);
+bool8_32 S9xDeinitUpdate(int Width, int Height);
 void S9xSetPalette();
 void S9xSyncSpeed();
 

--- a/src/gfx16.c
+++ b/src/gfx16.c
@@ -574,11 +574,6 @@ void S9xStartScreenRefresh()
 
    if (IPPU.RenderThisFrame)
    {
-      if (!S9xInitUpdate())
-      {
-         IPPU.RenderThisFrame = FALSE;
-         return;
-      }
       IPPU.RenderedFramesCount++;
       IPPU.PreviousLine = IPPU.CurrentLine = 0;
       IPPU.MaxBrightness = PPU.Brightness;
@@ -661,8 +656,7 @@ void S9xEndScreenRefresh()
       IPPU.ColorsChanged = FALSE;
       //}
 
-      S9xDeinitUpdate(IPPU.RenderedScreenWidth, IPPU.RenderedScreenHeight,
-                      1);
+      S9xDeinitUpdate(IPPU.RenderedScreenWidth, IPPU.RenderedScreenHeight);
    }
 
 #ifdef LAGFIX

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -122,7 +122,6 @@ void S9xUpdateHTimer()
 void S9xFixColourBrightness()
 {
    IPPU.XB = mul_brightness [PPU.Brightness];
-   if (Settings.SixteenBit)
    {
       unsigned int i;
       for (i = 0; i < 256; i++)

--- a/src/ppu_.c
+++ b/src/ppu_.c
@@ -120,7 +120,6 @@ void S9xUpdateHTimer(void)
 void S9xFixColourBrightness(void)
 {
    IPPU.XB = mul_brightness [PPU.Brightness];
-   if (Settings.SixteenBit)
    {
       unsigned i;
 


### PR DESCRIPTION
Drop S9xInitUpdate() which is only a stub here and was originally used
upstream in the Windows port until 1.52 where it was unused in the
Windows port as well. This function has already been removed in the
libretro snes9x2005 and 2010 cores.

Also drop checking the Settings.SixteenBit flag as this fork no longer
contains 8bpp graphics rendering code.