### PR TITLE
platform/miyoo: Fix build flags and use FAST_ALIGNED_LSB_WORD_ACCESS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,8 @@ else ifeq ($(platform), miyoo)
    ASM_CPU = 0
    ASM_SPC700 = 0
    SHARED := -shared -Wl,--version-script=libretro/link.T -Wl,--no-undefined
-   FLAGS += -fomit-frame-pointer -ffast-math -march=armv5te -mtune=arm926ej-s
-   FLAGS += -fno-unroll-loops
+   CFLAGS += -fomit-frame-pointer -ffast-math -fno-unroll-loops -flto -mcpu=arm926ej-s
+   CFLAGS += -DFAST_ALIGNED_LSB_WORD_ACCESS
 
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)

--- a/src/cpuaddr.h
+++ b/src/cpuaddr.h
@@ -145,6 +145,11 @@ static INLINE void AbsoluteLong()
 {
 #ifdef FAST_LSB_WORD_ACCESS
    OpAddress = (*(uint32*) CPU.PC) & 0xffffff;
+#elif defined FAST_ALIGNED_LSB_WORD_ACCESS
+   if (((int) CPU.PC & 1) == 0)
+      OpAddress = (*(uint16 *) CPU.PC) + (*(CPU.PC + 2) << 16);
+   else
+      OpAddress = *CPU.PC + ((*(uint16 *) (CPU.PC + 1)) << 8);
 #else
    OpAddress = *CPU.PC + (*(CPU.PC + 1) << 8) + (*(CPU.PC + 2) << 16);
 #endif
@@ -272,6 +277,11 @@ static INLINE void AbsoluteLongIndexedX()
 {
 #ifdef FAST_LSB_WORD_ACCESS
    OpAddress = (*(uint32*) CPU.PC + Registers.X.W) & 0xffffff;
+#elif defined FAST_ALIGNED_LSB_WORD_ACCESS
+   if (((int) CPU.PC & 1) == 0)
+      OpAddress = ((*(uint16 *) CPU.PC) + (*(CPU.PC + 2) << 16) + Registers.X.W) & 0xFFFFFF;
+   else
+      OpAddress = (*CPU.PC + ((*(uint16 *) (CPU.PC + 1)) << 8) + Registers.X.W) & 0xFFFFFF;
 #else
    OpAddress = (*CPU.PC + (*(CPU.PC + 1) << 8) + (*(CPU.PC + 2) << 16) + Registers.X.W) & 0xffffff;
 #endif

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -257,8 +257,13 @@ void S9xSetCPU(uint8 byte, uint16 Address)
          // Multiplicand
          uint32 res = Memory.FillRAM[0x4202] * byte;
 
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         *((uint16 *) &Memory.FillRAM[0x4216]) = res;
+#else
          Memory.FillRAM[0x4216] = (uint8) res;
          Memory.FillRAM[0x4217] = (uint8)(res >> 8);
+#endif
          break;
       }
       case 0x4204 :
@@ -268,15 +273,26 @@ void S9xSetCPU(uint8 byte, uint16 Address)
       case 0x4206 :
       {
          // Divisor
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         uint16 a = *((uint16 *) &Memory.FillRAM[0x4204]);
+#else
          uint16 a =
             Memory.FillRAM[0x4204] + (Memory.FillRAM[0x4205] << 8);
+#endif
          uint16 div = byte ? a / byte : 0xffff;
          uint16 rem = byte ? a % byte : a;
 
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         *((uint16 *) &Memory.FillRAM[0x4214]) = div;
+         *((uint16 *) &Memory.FillRAM[0x4216]) = rem;
+#else
          Memory.FillRAM[0x4214] = (uint8) div;
          Memory.FillRAM[0x4215] = div >> 8;
          Memory.FillRAM[0x4216] = (uint8) rem;
          Memory.FillRAM[0x4217] = rem >> 8;
+#endif
          break;
       }
       case 0x4207 :

--- a/src/ppu_.c
+++ b/src/ppu_.c
@@ -1496,8 +1496,13 @@ void S9xSetCPU(uint8 byte, uint16 Address)
          // Multiplicand
          uint32 res = Memory.FillRAM[0x4202] * byte;
 
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         *((uint16 *) &Memory.FillRAM[0x4216]) = res;
+#else
          Memory.FillRAM[0x4216] = (uint8) res;
          Memory.FillRAM[0x4217] = (uint8)(res >> 8);
+#endif
          break;
       }
       case 0x4204:
@@ -1507,14 +1512,25 @@ void S9xSetCPU(uint8 byte, uint16 Address)
       case 0x4206:
       {
          // Divisor
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         uint16 a = *((uint16 *) &Memory.FillRAM[0x4204]);
+#else
          uint16 a = Memory.FillRAM[0x4204] + (Memory.FillRAM[0x4205] << 8);
+#endif
          uint16 div = byte ? a / byte : 0xffff;
          uint16 rem = byte ? a % byte : a;
 
+#if defined FAST_LSB_WORD_ACCESS || defined FAST_ALIGNED_LSB_WORD_ACCESS
+         // assume malloc'd memory is 2-byte aligned
+         *((uint16 *) &Memory.FillRAM[0x4214]) = div;
+         *((uint16 *) &Memory.FillRAM[0x4216]) = rem;
+#else
          Memory.FillRAM[0x4214] = (uint8)div;
          Memory.FillRAM[0x4215] = div >> 8;
          Memory.FillRAM[0x4216] = (uint8)rem;
          Memory.FillRAM[0x4217] = rem >> 8;
+#endif
          break;
       }
       case 0x4207:


### PR DESCRIPTION
Backport FAST_ALIGNED_LSB_WORD_ACCESS from libretro/snes9x2005@c5d385d6
and libretro/snes9x2005@2572e073.
Fix build flags for miyoo, which were not correctly applied, opt-in to
FAST_ALIGNED_LSB_WORD_ACCESS as in libretro/snes9x2005#93, and use LTO
to squeeze a bit more performance and reduce the binary size by 4%.