### PR TITLE
Improve save state efficiency

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -706,11 +706,12 @@ void retro_run (void)
 
 size_t retro_serialize_size (void)
 {
-   uint8_t *tmpbuf = (uint8_t*)malloc(5000000);
-   memstream_set_buffer(tmpbuf, 5000000);
-   S9xFreezeGame("");
-   free(tmpbuf);
-   return memstream_get_last_size();
+   int32 size = SnapshotSize();
+
+   if (size < 0)
+      return 0;
+
+   return (size_t)size;
 }
 
 bool retro_serialize(void *data, size_t size)

--- a/src/snapshot.h
+++ b/src/snapshot.h
@@ -56,4 +56,6 @@ bool8 S9xUnfreezeGame(const char* filename);
 bool8 Snapshot(const char* filename);
 bool8 S9xLoadSnapshot(const char* filename);
 
+int32 SnapshotSize(void);
+
 #endif


### PR DESCRIPTION
At present, every time that `retro_serialize_size()` is called (i.e whenever save states are used), the core determines the save state size by allocating a temporary 5 MB (yes, 5 *megabytes*...) buffer and writing into this an actual save state. For a core that is focussed solely on performance, this is somewhat absurd... (on memory starved platforms, the temporary buffer allocation may even fail...)

With this PR, the save state size is now calculated independently of regular save state creation. No temporary buffer is required, and there is no need to actually write a save state to memory.