### PR TITLE
Make transparency effects configurable

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -597,6 +597,15 @@ static void check_variables(bool first_run)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       frameskip_interval = strtol(var.value, NULL, 10);
 
+   var.key = "snes9x2002_transparency";
+   var.value = NULL;
+
+   Settings.Transparency = true;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      if (strcmp(var.value, "disabled") == 0)
+         Settings.Transparency = false;
+
    var.key = "snes9x2002_low_pass_filter";
    var.value = NULL;
 

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -122,6 +122,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "1"
    },
    {
+      "snes9x2002_transparency",
+      "Transparency Effects",
+      NULL,
+      "Disable to improve frame rate at the expense of rendering accuracy.",
+      NULL,
+      NULL,
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled"
+   },
+   {
       "snes9x2002_low_pass_filter",
       "Audio Filter",
       NULL,


### PR DESCRIPTION
Reintroduce this option, which was present in the upstream version this
was forked from, to allow slower platforms to opt for improved frame
rates where rendering accuracy is not critical.